### PR TITLE
Create variable to ignore specific filetypes for highlight

### DIFF
--- a/doc/trailing-whitespace.txt
+++ b/doc/trailing-whitespace.txt
@@ -14,3 +14,13 @@ The repo is at http://github.com/bronson/vim-trailing-whitespace
 
 Originally based on http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 
+------------------------------------------------------------------------------
+VARIABLES                                   *FixWhitespace-variables*
+
+                                       g:extra_whitespace_ignored_filetypes
+g:extra_whitespace_ignored_filetypes
+    You can set filetypes to be ignored for highlight into this variable.
+
+  let g:extra_whitespace_ignored_filetypes = ['unite', 'mkd']
+
+		The default value is [].

--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -1,14 +1,25 @@
 if exists('loaded_trailing_whitespace_plugin') | finish | endif
 let loaded_trailing_whitespace_plugin = 1
 
+if !exists('g:extra_whitespace_ignored_filetypes')
+    let g:extra_whitespace_ignored_filetypes = []
+endif
+
+function! ShouldMatchWhitespace()
+    for ft in g:extra_whitespace_ignored_filetypes
+        if ft ==# &filetype | return 0 | endif
+    endfor
+    return 1
+endfunction
+
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight ExtraWhitespace ctermbg=darkred guibg=#382424
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
-autocmd BufWinEnter * match ExtraWhitespace /\s\+$/
+autocmd BufWinEnter * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
-autocmd InsertLeave * match ExtraWhitespace /\s\+$/
-autocmd InsertEnter * match ExtraWhitespace /\s\+\%#\@<!$/
+autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
+autocmd InsertEnter * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+\%#\@<!$/ | endif
 
 function! s:FixWhitespace(line1,line2)
     let l:save_cursor = getpos(".")


### PR DESCRIPTION
I have a problem with the combination of this plugin and [unite.vim](https://github.com/Shougo/unite.vim).
Because unite.vim shows extra whitespace from the end of the line, the unite buffer becomes like [this](https://camo.githubusercontent.com/0b6b0d3c3e442faf0278351a38869d696ad7d35c/68747470733a2f2f662e636c6f75642e6769746875622e636f6d2f6173736574732f333937392f323336363231342f38396637363737632d613666352d313165332d383635332d3435323866653033663037662e706e67).
So I want this plugin not to highlight buffer with unite FileType.

And markdown needs extra whitespace to start a new line, I want to disable this highlight for buffer with mkd FileType too.

So I introduced `g:extra_whitespace_ignored_filetypes` option to solve such problems.
