### PR TITLE
Make it a lot easier to override highlighting

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -13,7 +13,7 @@ function! ShouldMatchWhitespace()
 endfunction
 
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
-highlight ExtraWhitespace ctermbg=darkred guibg=#382424
+highlight default ExtraWhitespace ctermbg=darkred guibg=#382424
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
 autocmd BufWinEnter * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
 


### PR DESCRIPTION
Adding default to the highlight line make sure that the highlighting won't be overwritten if it's already set in a user colorscheme.