### PR TITLE
Change whitespace highlighting event to BufRead

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -15,7 +15,7 @@ endfunction
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight ExtraWhitespace ctermbg=darkred guibg=#382424
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
-autocmd BufWinEnter * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
+autocmd BufRead * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
 autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif


### PR DESCRIPTION
This PR change whitespace highlighting event from BufWinEnter to BufRead because `g:extra_whitespace_ignored_filetypes` option not applied to opened buffers.