### PR TITLE
Do not remove whitespace that is preceeded by if backslash

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -15,15 +15,15 @@ endfunction
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight default ExtraWhitespace ctermbg=darkred guibg=#382424
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
-autocmd BufRead * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
+autocmd BufRead * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<!\s\+$/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
-autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
-autocmd InsertEnter * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+\%#\@<!$/ | endif
+autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<!\s\+$/ | endif
+autocmd InsertEnter * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<!\s\+\%#\@<!$/ | endif
 
 function! s:FixWhitespace(line1,line2)
     let l:save_cursor = getpos(".")
-    silent! execute ':' . a:line1 . ',' . a:line2 . 's/\s\+$//'
+    silent! execute ':' . a:line1 . ',' . a:line2 . 's/\\\@<!\s\+$//'
     call setpos('.', l:save_cursor)
 endfunction
 


### PR DESCRIPTION
Trailing whitespace can be useful in .vimrc files if we want to set a
string property that ends in whitespace. For example:

    set showbreak=↪\ \ \

This change adds a "\\\@<!" at the start of every regex in the plugin