### PR TITLE
Make highlight customizable and U+3000 character support

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -5,7 +5,7 @@ if !exists('g:extra_whitespace_ignored_filetypes')
     let g:extra_whitespace_ignored_filetypes = []
 endif
 
-function! ShouldMatchWhitespace()
+function! s:ShouldMatchWhitespace()
     for ft in g:extra_whitespace_ignored_filetypes
         if ft ==# &filetype | return 0 | endif
     endfor
@@ -15,11 +15,11 @@ endfunction
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight default ExtraWhitespace ctermbg=darkred guibg=#382424
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
-autocmd BufRead,BufNew * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | else | match ExtraWhitespace /^^/ | endif
+autocmd BufRead,BufNew * if s:ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | else | match ExtraWhitespace /^^/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
-autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
-autocmd InsertEnter * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+\%#\@<!$/ | endif
+autocmd InsertLeave * if s:ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
+autocmd InsertEnter * if s:ShouldMatchWhitespace() | match ExtraWhitespace /\s\+\%#\@<!$/ | endif
 
 function! s:FixWhitespace(line1,line2)
     let l:save_cursor = getpos(".")

--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -15,11 +15,11 @@ endfunction
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight default ExtraWhitespace ctermbg=darkred guibg=#382424
 autocmd ColorScheme * highlight default ExtraWhitespace ctermbg=red guibg=red
-autocmd BufRead,BufNew * if s:ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | else | match ExtraWhitespace /^^/ | endif
+autocmd BufRead,BufNew * if s:ShouldMatchWhitespace() | match ExtraWhitespace /[\u3000[:space:]]\+$/ | else | match ExtraWhitespace /^^/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
-autocmd InsertLeave * if s:ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
-autocmd InsertEnter * if s:ShouldMatchWhitespace() | match ExtraWhitespace /\s\+\%#\@<!$/ | endif
+autocmd InsertLeave * if s:ShouldMatchWhitespace() | match ExtraWhitespace /[\u3000[:space:]]\+$/ | endif
+autocmd InsertEnter * if s:ShouldMatchWhitespace() | match ExtraWhitespace /[\u3000[:space:]]\+\%#\@<!$/ | endif
 
 function! s:FixWhitespace(line1,line2)
     let l:save_cursor = getpos(".")

--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -14,7 +14,7 @@ endfunction
 
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight default ExtraWhitespace ctermbg=darkred guibg=#382424
-autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
+autocmd ColorScheme * highlight default ExtraWhitespace ctermbg=red guibg=red
 autocmd BufRead,BufNew * if s:ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | else | match ExtraWhitespace /^^/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode


### PR DESCRIPTION
Hi.
Thanks for developing a nice plugin!
I found highlight is not customizable, and
I needed 'IDEOGRAPHIC SPACE' character (U+3000) support.
The character is used in CJK locale.

- 170ea495ce53b95599193608919c4618e0094b46 `ShouldMatchWhitespace()` should be script-local :)
- 8231ac7cdb86e867d7bdf6050d177fc4fc3c1a6e Make highlight customizable in .vimrc
  - My .vimrc config is:

```viml
highlight ExtraWhitespace cterm=underline gui=underline ctermfg=4 guifg=Cyan
autocmd ColorScheme * highlight ExtraWhitespace cterm=underline gui=underline ctermfg=4 guifg=Cyan
```

- 9a4742777777f686f692a66017196cb3a952b7a1 Support 'IDEOGRAPHIC SPACE' character (U+3000)
  - See http://www.fileformat.info/info/unicode/char/3000/index.htm for the details