### PR TITLE
fix whitespace highlight bug

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -15,7 +15,7 @@ endfunction
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight default ExtraWhitespace ctermbg=darkred guibg=#382424
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
-autocmd BufRead * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif
+autocmd BufRead,BufNew * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | else | match ExtraWhitespace /^^/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
 autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif


### PR DESCRIPTION
Hi, bronson,

There may be a bug when using g:extra_whitespace_ignored_filetypes and vim split window.
I find this bug when using [Conque-GDB](https://github.com/vim-scripts/Conque-GDB): another vim script for cpp debugging.

In short:
1. It is better to match NOTHING(here I use `^^`, which pattern will never occur) to `ExtraWhitespace` if `ShouldMatchWhitespace()` function returns `0`. Otherwise ExtraWhitespace will not change in **another** split-vim-window.
2. Only `audocmd BufRead` is not enough for my case. Here I add `BufNew`.

Otherwise, even if I added `let g:extra_whitespace_ignored_filetypes = ['conque_term']`, the vim looked like (see the red whitespace highlights in the below window):
![2016-02-28 3 17 17](https://cloud.githubusercontent.com/assets/5916148/13377988/a6d5051c-de2e-11e5-8aa8-54668f5049cc.png)

