### PR TITLE
add autocmd pattern for vimfiler

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -15,7 +15,7 @@ endfunction
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight default ExtraWhitespace ctermbg=darkred guibg=#382424
 autocmd ColorScheme * highlight ExtraWhitespace ctermbg=red guibg=red
-autocmd BufRead,BufNew * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | else | match ExtraWhitespace /^^/ | endif
+autocmd filetype,BufRead,BufNew * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | else | match ExtraWhitespace /^^/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
 autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\s\+$/ | endif


### PR DESCRIPTION
Hi bronson !
Thank you for great plugin.
However, this plugin could not work well with [Shougo/vimfiler](https://github.com/Shougo/vimfiler.vim)
It seems that exist autocmds in your script are not issued.
Then, I appended `filetype` autocmd pattern. and it works well.
Thanks
