### PR TITLE
Disable on non-writable buffers

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -6,6 +6,7 @@ if !exists('g:extra_whitespace_ignored_filetypes')
 endif
 
 function! ShouldMatchWhitespace()
+    if &buftype !=# '' && &buftype !=# 'acwrite' | return 0 | endif
     for ft in g:extra_whitespace_ignored_filetypes
         if ft ==# &filetype | return 0 | endif
     endfor


### PR DESCRIPTION
It doesn't make sense to highlight whitespace on non-writable buffers because they cannot be changed by the user. By `:help buftype` the only buffers we care about are those whose `&buftype` is either empty or
`acwrite`