### PR TITLE
fix: when filetype is changed, reconsider excluded filetypes

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -15,7 +15,7 @@ endfunction
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight default ExtraWhitespace ctermbg=darkred guibg=darkred
 autocmd ColorScheme * highlight default ExtraWhitespace ctermbg=darkred guibg=darkred
-autocmd BufRead,BufNew * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<![\u3000[:space:]]\+$/ | else | match ExtraWhitespace /^^/ | endif
+autocmd BufRead,BufNew,FileType * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<![\u3000[:space:]]\+$/ | else | match ExtraWhitespace /^^/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
 autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<![\u3000[:space:]]\+$/ | endif


### PR DESCRIPTION
Some plugins, e.g., fzf-lua, only set the filetype after creating a new buffer. To exclude the later-set filetype correctly, rerun the setup.