### PR TITLE
Don't highlight in terminal buffers

### DIFF
--- a/plugin/trailing-whitespace.vim
+++ b/plugin/trailing-whitespace.vim
@@ -9,13 +9,14 @@ function! ShouldMatchWhitespace()
     for ft in g:extra_whitespace_ignored_filetypes
         if ft ==# &filetype | return 0 | endif
     endfor
+    if &buftype ==# 'terminal' | return 0 | endif
     return 1
 endfunction
 
 " Highlight EOL whitespace, http://vim.wikia.com/wiki/Highlight_unwanted_spaces
 highlight default ExtraWhitespace ctermbg=darkred guibg=darkred
 autocmd ColorScheme * highlight default ExtraWhitespace ctermbg=darkred guibg=darkred
-autocmd BufRead,BufNew,FileType * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<![\u3000[:space:]]\+$/ | else | match ExtraWhitespace /^^/ | endif
+autocmd BufRead,BufNew,FileType,TermOpen * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<![\u3000[:space:]]\+$/ | else | match ExtraWhitespace /^^/ | endif
 
 " The above flashes annoyingly while typing, be calmer in insert mode
 autocmd InsertLeave * if ShouldMatchWhitespace() | match ExtraWhitespace /\\\@<![\u3000[:space:]]\+$/ | endif


### PR DESCRIPTION
When opening a buffer with `:terminal` trailing whitespace is highlighted in there too.

However, this doesn't make much sense. Many programs emit trailing whitespace and highlighting it distracts from their output. Even the user's cursor is considered whitespace so there's always a useless highlight.

If the user is interested in trailing outspace in the output of programs for later document formatting, they can apply such text formatting in the document's buffer, where this plugin will be active.

Detect terminal buffers and consider them not valid for this plugin.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>